### PR TITLE
Use .env for password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,20 @@
 # IMAGE_POSTGRES=artifactory.company.com/docker-remote/library/postgres:17.5-alpine
 
 # ==========================================
+# Database Password (CHANGE THIS!)
+# ==========================================
+# PostgreSQL admin password
+# Default: Random password (generate your own!)
+#
+# Note: With trust authentication enabled (pg_hba.conf), this password
+#       is not required for local connections. It's set to suppress
+#       docker-compose warnings and for potential future use.
+#
+# Generate secure password:
+#   openssl rand -base64 32
+POSTGRES_PASSWORD=changeme_generate_random_password
+
+# ==========================================
 # Port Configuration
 # ==========================================
 # Port to expose pagila on localhost (127.0.0.1 only - security!)

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *password.txt
+.env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,10 +8,6 @@ volumes:
     #   o: bind
     #   device: /host/path/dbfiles
 
-secrets:
-  pg_sa_pw:
-    file: ./postgres_sa_password.txt  # create & modify this file before running
-
 services:
   pagila:
     # Corporate Environment Support: Uses IMAGE_POSTGRES from .env
@@ -21,13 +17,13 @@ services:
     container_name: pagila-postgres    # Renamed for platform consistency
     restart: unless-stopped
 
-    secrets:
-      - pg_sa_pw
-
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: pagila
-      POSTGRES_PASSWORD_FILE: /run/secrets/pg_sa_pw
+      # Password from .env (consistent with platform pattern)
+      # Note: Not actually used with trust authentication (pg_hba.conf)
+      #       Just suppresses docker-compose warnings
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     
     volumes:
       # Named volume keeps data between runs (see FAQ below for the host path)


### PR DESCRIPTION
Use .env instead of password file for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>