### PR TITLE
Unified pagila configuration for platform integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,9 @@ services:
       - ./pagila-schema.sql:/docker-entrypoint-initdb.d/1-pagila-schema.sql
       - ./pagila-schema-jsonb.sql:/docker-entrypoint-initdb.d/2-pagila-schema-jsonb.sql
       - ./pagila-data.sql:/docker-entrypoint-initdb.d/3-pagila-data.sql
-      # - ./restore-pagila-data-jsonb.sql:/docker-entrypoint-initdb.d/4-restore-pagila-data-jsonb.sql
-      # - ./pagila-data-yum-jsonb.backup:/docker-entrypoint-initdb.d/pagila-data-yum-jsonb.backup
-      # - ./pagila-data-apt-jsonb.backup:/docker-entrypoint-initdb.d/pagila-data-apt-jsonb.backup
+      - ./restore-pagila-data-jsonb.sql:/docker-entrypoint-initdb.d/4-restore-pagila-data-jsonb.sql
+      - ./pagila-data-yum-jsonb.backup:/docker-entrypoint-initdb.d/pagila-data-yum-jsonb.backup
+      - ./pagila-data-apt-jsonb.backup:/docker-entrypoint-initdb.d/pagila-data-apt-jsonb.backup
 
       # Bind-mount read-only config that enables 'trust' network auth
       - ./pg_hba.conf:/etc/postgresql/pg_hba.conf:ro


### PR DESCRIPTION
## Summary

This PR unifies and supersedes two previous branches to create a working pagila configuration:
- `feature/use-env-for-password` - Environment-based configuration  
- `fix/database-configuration` - Database naming fixes

**Target: develop branch** (keeping main untouched to track upstream)

## What This Fixes

### Problem 1: Data Loading Into Wrong Database
**Issue**: Pagila data was loading into `postgres` database instead of `pagila`
**Fix**: Added `POSTGRES_DB: pagila` to docker-compose.yml

### Problem 2: JSONB Data Not Loading
**Issue**: Restore scripts were commented out
**Fix**: Enabled restore-pagila-data-jsonb.sql and backup mounting

### Problem 3: Platform Integration Issues
**Issue**: docker-compose.yaml vs docker-compose.yml naming mismatch
**Fix**: Uses docker-compose.yml to match setup script expectations

## Key Features

### 🔧 Database Configuration
- ✅ `POSTGRES_DB: pagila` - data loads into correct database
- ✅ Password from .env file: `${POSTGRES_PASSWORD:-postgres}`
- ✅ Trust authentication for developer-friendly local access

### 📦 JSONB Data Support  
- ✅ Restores APT and YUM package data for testing
- ✅ Uses SQL syntax with proper error handling
- ✅ All backup files properly mounted

### 🏢 Corporate Environment Support
- ✅ Environment variable for PostgreSQL image: `${IMAGE_POSTGRES:-postgres:17.5-alpine}`
- ✅ .env.example with comprehensive documentation
- ✅ .gitignore to keep .env files out of version control

### 👨‍💻 Developer Experience
- ✅ Trust authentication via pg_hba.conf - no passwords needed locally
- ✅ pgAdmin4 pre-configured on port 5050
- ✅ Makefile with common operations (start, stop, clean, etc.)

## Platform Integration Update Required

The airflow-data-platform setup script has been updated (in this PR's companion) to:
- Clone the `develop` branch instead of default branch
- This ensures users get our customized version, not upstream

## Testing

```bash
# Clone and test
git clone -b develop https://github.com/Troubladore/pagila.git
cd pagila

# Start services
docker-compose up -d

# Verify database exists with data
docker exec pagila psql -U postgres -d pagila -c 'SELECT COUNT(*) FROM film;'
# Should return 1000 films
```

## Migration Plan

1. Merge this PR to `develop` branch
2. Delete superseded branches:
   - `feature/use-env-for-password`
   - `fix/database-configuration`  
3. Keep `main` branch untouched (tracks upstream)
4. All platform work happens in `develop`

Fixes setup error: "pagila database not found"