### PR TITLE
fix: Prevent unnecessary Docker image pulls with pull_policy: missing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     # Default: postgres:17.5-alpine (current version, small security footprint)
     # Corporate: Set in .env to use Artifactory mirror
     image: ${IMAGE_POSTGRES:-postgres:17.5-alpine}
+    pull_policy: missing  # Only pull if image doesn't exist locally (never re-pull)
     container_name: pagila-postgres    # Renamed for platform consistency
     restart: unless-stopped
 
@@ -100,6 +101,7 @@ services:
   # whereas TCP connection below will take longer
   pagila-jsonb-restore:
     image: ${IMAGE_POSTGRES:-postgres:17.5-alpine}  # Use same image as main service
+    pull_policy: missing  # Only pull if image doesn't exist locally (never re-pull)
     container_name: pagila-jsonb-restore
     depends_on:
       pagila:


### PR DESCRIPTION
## Summary
Prevents Docker Compose from re-pulling images that already exist locally by adding explicit `pull_policy: missing` to both services.

## Problem
Corporate testers reported that Docker Compose was re-pulling images even when they existed locally, causing:
- Slow startup times with authenticated registries
- Unnecessary network traffic
- Authentication prompts for already-cached corporate images

## Solution
Added `pull_policy: missing` to both services in docker-compose.yml:
- ✅ `pagila` service (main PostgreSQL database)
- ✅ `pagila-jsonb-restore` service (data restoration)

## Behavior Change
**Before:** Docker Compose might pull images even if they exist locally (especially `:latest` tags or during compose up)

**After:** Images only pulled if they don't exist locally (never re-pulled)

## Testing
- [x] Verified with existing local images - no pulls attempted
- [x] Verified with missing images - correctly pulls when needed
- [x] Corporate tester confirmed no more unnecessary pulls

## Documentation
Ref: https://docs.docker.com/compose/compose-file/pull-policy/

## Related
- Part of airflow-data-platform PR #115
- Addresses corporate environment feedback